### PR TITLE
Add JVM-argument --add-opens to fix Reload Configurations classloading issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /wip
 build.properties
 /.idea/
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /download
 /wip
 build.properties
+/.idea/

--- a/build.xml
+++ b/build.xml
@@ -712,6 +712,7 @@
 		<property name="spawn" value="true"/>
 		<java jvm="${tomcat.java.jvm}" classname="org.apache.catalina.startup.Bootstrap" fork="true" failonerror="true" spawn="${spawn}" maxmemory="${maxmemory}" if:true="${use.java}">
 			<jvmarg value="-Dcatalina.home=${tomcat.dir}"/>
+			<!-- Fixes classloading issue, see https://github.com/wearefrank/frank-runner/pull/86 -->
 			<jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/>
 			<arg value="${action}"/>
 			<classpath>

--- a/build.xml
+++ b/build.xml
@@ -712,6 +712,7 @@
 		<property name="spawn" value="true"/>
 		<java jvm="${tomcat.java.jvm}" classname="org.apache.catalina.startup.Bootstrap" fork="true" failonerror="true" spawn="${spawn}" maxmemory="${maxmemory}" if:true="${use.java}">
 			<jvmarg value="-Dcatalina.home=${tomcat.dir}"/>
+			<jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/>
 			<arg value="${action}"/>
 			<classpath>
 				<fileset dir="${tomcat.dir}/bin"><include name="*.jar"/></fileset>

--- a/build.xml
+++ b/build.xml
@@ -712,8 +712,7 @@
 		<property name="spawn" value="true"/>
 		<java jvm="${tomcat.java.jvm}" classname="org.apache.catalina.startup.Bootstrap" fork="true" failonerror="true" spawn="${spawn}" maxmemory="${maxmemory}" if:true="${use.java}">
 			<jvmarg value="-Dcatalina.home=${tomcat.dir}"/>
-			<!-- Fixes classloading issue, see https://github.com/wearefrank/frank-runner/pull/86 -->
-			<jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/>
+			<jvmarg value="--add-opens=java.base/java.lang=ALL-UNNAMED"/><!-- Fixes classloading issue, see https://github.com/wearefrank/frank-runner/pull/86 -->
 			<arg value="${action}"/>
 			<classpath>
 				<fileset dir="${tomcat.dir}/bin"><include name="*.jar"/></fileset>


### PR DESCRIPTION
1. Add JVM-argument --add-opens to fix Reload Configurations classloading issue
2. ignore IntelliJ folder for Git

Fix 1 is needed if you click at `Reload Configurations` in the console. Without it, the `-add-opens` parameters are not correctly pass through the classloaders who are trying to load the classes in the Configurations used. The first load of configurations works fine, but reloads are failing with:
`2024-03-13 10:52:02,045 ERROR [http-nio-80-exec-9] {} lifecycle.ApplicationMessageEvent - Application [MyFirstFrank] an exception occurred while loading configuration [IAF_Util]
java.lang.NullPointerException: Cannot invoke "String.hashCode()" because "<local2>" is null`

With the default examples inside `frank-runner` I did not get this reproduced. But with the Academy project `../MyFirstFrank` it happened. 
Adding this `jvmargs` fixes the below class loading issue and the previous strange NPE is gone as well. 

Here is the used configuration (renamed, because GitHub refuses .xml files): 
[Configuration.xml.txt](https://github.com/wearefrank/frank-runner/files/14586174/Configuration.xml.txt)

Part of the stacktrace which is solved by this PR:
```
2024-03-13 10:52:02,016 ERROR [http-nio-80-exec-9] {} digester3.Digester - Begin event threw exception
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'org.frankframework.jdbc.XmlQuerySender': 
Initialization of bean failed; nested exception is org.springframework.aop.framework.AopConfigException: Could not 
generate CGLIB subclass of class org.frankframework.jdbc.XmlQuerySender: Common causes of this problem include 
using a final class or a non-visible class; nested exception is org.springframework.cglib.core.ReflectUtils$6:
 ClassLoader mismatch for [org.frankframework.jdbc.XmlQuerySender]: JVM should be started with 
--add-opens=java.base/java.lang=ALL-UNNAMED for ClassLoader.defineClass to be accessible on 
org.frankframework.configuration.classloaders.WebAppClassLoader; consider co-locating the affected class in that 
target ClassLoader instead.
```
