### PR TITLE
Allow for a uniform way to define configurations.dir

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -23,6 +23,11 @@
 		<available property="pom.xml.available" file="${projects.dir}/${project.dir}/pom.xml"/>
 
 		<property name="classes.dir" value="${war.dir}/src/main/resources" if:set="war.pom.xml.available"/>
+		<!-- To support CI/CD - with the project.dir we want to manipulate
+		     what code we want to run (Nexus release of FF!, local build of FF!,
+			 or ladybug-ff-test-webapp). Then we need another way to specify
+			 what configurations to run -->
+		<property name="configurations.dir" value="${override.configurations.dir}" if:set="override.configurations.dir"/>
 		<property name="configurations.dir" value="${war.dir}/src/main/configurations" if:set="war.pom.xml.available"/>
 		<property name="java.dir" value="${war.dir}/src/main/java" if:set="war.pom.xml.available"/>
 		<property name="tests.dir" value="${war.dir}/src/test/testtool" if:set="war.pom.xml.available"/>

--- a/build.xml
+++ b/build.xml
@@ -23,11 +23,7 @@
 		<available property="pom.xml.available" file="${projects.dir}/${project.dir}/pom.xml"/>
 
 		<property name="classes.dir" value="${war.dir}/src/main/resources" if:set="war.pom.xml.available"/>
-		<!-- To support CI/CD - with the project.dir we want to manipulate
-		     what code we want to run (Nexus release of FF!, local build of FF!,
-			 or ladybug-ff-test-webapp). Then we need another way to specify
-			 what configurations to run -->
-		<property name="configurations.dir" value="${override.configurations.dir}" if:set="override.configurations.dir"/>
+		<property name="configurations.dir" value="${override.configurations.dir}" if:set="override.configurations.dir"/><!-- Enables CI/CD to choose configurations in frank-runner/build.properties. See https://github.com/wearefrank/ladybug-ff-cypress-test/blob/main/.github/workflows/testing.js.yml -->
 		<property name="configurations.dir" value="${war.dir}/src/main/configurations" if:set="war.pom.xml.available"/>
 		<property name="java.dir" value="${war.dir}/src/main/java" if:set="war.pom.xml.available"/>
 		<property name="tests.dir" value="${war.dir}/src/test/testtool" if:set="war.pom.xml.available"/>


### PR DESCRIPTION
This is needed when CI/CD wants to use the Frank!Runner in many different ways. When you use frank-runner/specials/iaf-webapp or ladybug-ff-test-webapp, then project.dir is used to start the right version or the right Spring configuration of the FF!. Property configurations.dir is needed to reference the configurations we want to test against, typically somewhere in ladybug-ff-cypress-test.

Without this PR, you would have to use project.dir instead in case you start the Nexus release of the Frank!Framework. With this PR in place, you can always use frank-runner/build.properties to manage configurations.dir, independent from the chosen version / Spring configuration.